### PR TITLE
fixed depricated lsp config for latest version

### DIFF
--- a/lua/plugins/lsp.lua
+++ b/lua/plugins/lsp.lua
@@ -1,5 +1,5 @@
 local capabilities = vim.lsp.protocol.make_client_capabilities()
-capabilities = require('cmp_nvim_lsp').update_capabilities(capabilities)
+capabilities = require('cmp_nvim_lsp').default_capabilities(capabilities)
 
 local ok, lsp = pcall(require, 'lspconfig')
 if not ok then


### PR DESCRIPTION
Nvim wasn't working after plugins update so here's the fix.